### PR TITLE
Reduce thread/statefulness of current dumping solution

### DIFF
--- a/UWPDumper/source/UWP/UWP.cpp
+++ b/UWPDumper/source/UWP/UWP.cpp
@@ -28,12 +28,14 @@ ComPtr<ABI::Windows::Storage::IApplicationData> GetIApplicationData()
 	)
 	{
 		// Error getting ApplicationData statics
+		return nullptr;
 	}
 
 	ComPtr<ABI::Windows::Storage::IApplicationData> AppData;
 	if( AppDataStatics->get_Current(&AppData) < 0 )
 	{
 		// Error getting current IApplicationData
+		return nullptr;
 	}
 
 	return AppData;
@@ -66,11 +68,16 @@ ComPtr<ABI::Windows::ApplicationModel::IPackageId> GetCurrentPackageID()
 {
 	ComPtr<ABI::Windows::ApplicationModel::IPackage> CurrentPackage =
 		GetCurrentPackage();
+	if( !CurrentPackage )
+	{
+		// Error getting current package
+		return nullptr;
+	}
 
 	ComPtr<ABI::Windows::ApplicationModel::IPackageId> CurrentPackageID;
 	if( CurrentPackage->get_Id(&CurrentPackageID) < 0 )
 	{
-		// error getting current package ID
+		// Error getting current package ID
 		return nullptr;
 	}
 	return CurrentPackageID;
@@ -201,6 +208,11 @@ std::wstring UWP::Current::GetArchitecture()
 std::wstring UWP::Current::GetPublisher()
 {
 	ComPtr<ABI::Windows::ApplicationModel::IPackageId> PackageID = GetCurrentPackageID();
+	if( !PackageID )
+	{
+		// Error getting current Package ID
+		return L"";
+	}
 
 	HString PublisherString;
 
@@ -360,7 +372,11 @@ std::wstring UWP::Current::Storage::GetRoamingPath()
 std::wstring UWP::Current::Storage::GetTemporaryPath()
 {
 	ComPtr<ABI::Windows::Storage::IApplicationData> AppData = GetIApplicationData();
-
+	if( !AppData )
+	{
+		// Error getting Application Data;
+		return L"";
+	}
 	ComPtr<ABI::Windows::Storage::IStorageFolder> TemporaryFolder;
 
 	if( AppData->get_TemporaryFolder(&TemporaryFolder) < 0 )


### PR DESCRIPTION
In relation to #13:
This is to optimize the dumping path into something more stable and generic across games that would hit less of the commonly-mitigated methods.
Less threads, less IPC-statefulness or dependency, and hopefully making the DLL more independent so that you wouldn't even have to use UWPInjector if you didn't want to.